### PR TITLE
Cross Scala 2.10 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "base64 root project"
 
 scalaVersion := "2.12.0"
 
-crossScalaVersions := Seq("2.12.0","2.11.8")
+crossScalaVersions := Seq("2.12.0","2.11.8", "2.10.6")
 
 lazy val root = project.in(file("."))
   .aggregate(JS, JVM)


### PR DESCRIPTION
Just allow this library can be used in Scala 2.10. In my case, because I'm developing an SBT plugin that uses this library in a transitive way.

I've executed all tests locally and everything looks fine.

Thanks!