### PR TITLE
Add support for Scalajs 1.x.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,10 +13,7 @@ lazy val base64 = crossProject(JVMPlatform, JSPlatform, NativePlatform) // Nativ
   .settings(commonSettings)
   .settings(
     libraryDependencies +=
-      (if (scalaVersion.value.startsWith("2.11"))
-         "com.lihaoyi" %%% "utest" % "0.6.8" % Test
-       else
-         "com.lihaoyi" %%% "utest" % "0.6.9" % Test),
+      "com.lihaoyi" %%% "utest" % "0.7.5" % Test,
     testFrameworks += new TestFramework("utest.runner.Framework"),
     name := "Base64",
     organization := "com.github.marklister",
@@ -46,14 +43,14 @@ lazy val base64 = crossProject(JVMPlatform, JSPlatform, NativePlatform) // Nativ
     initialCommands in console := """import com.github.marklister.base64.Base64._"""
   )
   .nativeSettings(
-    scalaVersion := "2.11.12",
-    crossScalaVersions := Seq("2.11.12"),  //TODO +publish tries to publish n times.
+    scalaVersion := "2.12.12",
+    crossScalaVersions := Seq("2.12.12"),  //TODO +publish tries to publish n times.
     nativeLinkStubs := true
   )
 
 val commonSettings = Seq(
-  scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0")
+  scalaVersion := "2.12.12",
+  crossScalaVersions := Seq("2.12.12", "2.13.4")
 )
 lazy val JVM = base64.jvm
 lazy val JS = base64.project js

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")


### PR DESCRIPTION
This PR adds support for Scalajs 1.x.x (note that Scalajs 0.6.x is no longer maintained nor supported). Since Scalajs 1.x.x doesn't support Scala 2.11.x, its support was dropped.